### PR TITLE
package bundle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,6 @@ parameters:
 orbs:
   slack: circleci/slack@4.2.1
   gravitee: gravitee-io/gravitee@1.0
-  # gravitee: gravitee-io/gravitee@dev:1.0.4
   secrethub: secrethub/cli@1.1.0
   # secrethub: secrethub/cli@1.0.0
 
@@ -97,6 +96,17 @@ workflows:
           # container_gun_image_name: 'openjdk'
           # container_gun_image_tag: '11.0.3-jdk-stretch'
           container_size: 'large'
+      - gravitee/d_standalone_package_bundle_secrets:
+          context: cicd-orchestrator
+          name: package_bundle_secrets_resolution
+          requires:
+            - maven_n_git_release
+      - gravitee/d_http_sign_policy_package_bundle:
+          name: package_bundle
+          requires:
+            - package_bundle_secrets_resolution
+          dry_run: << pipeline.parameters.dry_run >>
+          maven_profile_id: << pipeline.parameters.maven_profile_id >>
 
   release_dry_run:
     when:
@@ -118,6 +128,18 @@ workflows:
           # container_gun_image_name: 'openjdk'
           # container_gun_image_tag: '11.0.3-jdk-stretch'
           container_size: 'large'
+      - gravitee/d_standalone_package_bundle_secrets:
+          context: cicd-orchestrator
+          name: package_bundle_secrets_resolution
+          requires:
+            - maven_n_git_release
+      - gravitee/d_http_sign_policy_package_bundle:
+          name: package_bundle
+          requires:
+            - package_bundle_secrets_resolution
+          dry_run: << pipeline.parameters.dry_run >>
+          maven_profile_id: << pipeline.parameters.maven_profile_id >>
+
   # ---
   # CICD Workflow For APIM Orchestrated Nexus Staging, Container-based : Circle CI Docker Executor
   nexus_staging:
@@ -165,6 +187,17 @@ workflows:
           # container_gun_image_name: 'openjdk'
           # container_gun_image_tag: '11.0.3-jdk-stretch'
           container_size: 'large'
+      - gravitee/d_standalone_package_bundle_secrets:
+          context: cicd-orchestrator
+          name: package_bundle_secrets_resolution
+          requires:
+            - maven_n_git_release
+      - gravitee/d_http_sign_policy_package_bundle:
+          name: package_bundle
+          requires:
+            - package_bundle_secrets_resolution
+          dry_run: << pipeline.parameters.dry_run >>
+          maven_profile_id: << pipeline.parameters.maven_profile_id >>
 
   standalone_release_dry_run:
     when:
@@ -186,6 +219,17 @@ workflows:
           # container_gun_image_name: 'openjdk'
           # container_gun_image_tag: '11.0.3-jdk-stretch'
           container_size: 'large'
+      - gravitee/d_standalone_package_bundle_secrets:
+          context: cicd-orchestrator
+          name: package_bundle_secrets_resolution
+          requires:
+            - maven_n_git_release
+      - gravitee/d_http_sign_policy_package_bundle:
+          name: package_bundle
+          requires:
+            - package_bundle_secrets_resolution
+          dry_run: << pipeline.parameters.dry_run >>
+          maven_profile_id: << pipeline.parameters.maven_profile_id >>
 
   standalone_nexus_staging:
     # ---
@@ -261,6 +305,17 @@ workflows:
           # container_gun_image_name: 'openjdk'
           # container_gun_image_tag: '11.0.3-jdk-stretch'
           container_size: 'large'
+      - gravitee/d_standalone_package_bundle_secrets:
+          context: cicd-orchestrator
+          name: package_bundle_secrets_resolution
+          requires:
+            - maven_n_git_release
+      - gravitee/d_http_sign_policy_package_bundle:
+          name: package_bundle
+          requires:
+            - package_bundle_secrets_resolution
+          dry_run: << pipeline.parameters.dry_run >>
+          maven_profile_id: << pipeline.parameters.maven_profile_id >>
 
   standalone_release_replay_dry_run:
     when:
@@ -283,6 +338,17 @@ workflows:
           # container_gun_image_name: 'openjdk'
           # container_gun_image_tag: '11.0.3-jdk-stretch'
           container_size: 'large'
+      - gravitee/d_standalone_package_bundle_secrets:
+          context: cicd-orchestrator
+          name: package_bundle_secrets_resolution
+          requires:
+            - maven_n_git_release
+      - gravitee/d_http_sign_policy_package_bundle:
+          name: package_bundle
+          requires:
+            - package_bundle_secrets_resolution
+          dry_run: << pipeline.parameters.dry_run >>
+          maven_profile_id: << pipeline.parameters.maven_profile_id >>
 
   standalone_nexus_staging_replay:
     # ---


### PR DESCRIPTION
package bundle for `gravitee-policy-http-signature` is now supported by both standalone release and standalone release replay workflows
