### PR TITLE
chore: bump Gravitee deps to make policy compatible >= 3.15.x

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -35,6 +35,17 @@ You can use:
 
 NOTE: Current version of the policy does not support *Digest*, *(request-target)*, *Host* and *Path* header.
 
+
+== Compatibility with APIM
+
+|===
+|Plugin version | APIM version
+
+|2.x and upper                  | 3.15.x to latest
+|Up to 1.5.0                    | Up to 3.14.x
+|===
+
+
 == Configuration
 
 |===

--- a/pom.xml
+++ b/pom.xml
@@ -37,9 +37,10 @@
 
     <properties>
         <gravitee-gateway.version>3.6.3</gravitee-gateway.version>
-        <gravitee-gateway-api.version>1.31.0</gravitee-gateway-api.version>
-        <gravitee-policy-api.version>1.10.0</gravitee-policy-api.version>
-        <gravitee-common.version>1.18.0</gravitee-common.version>
+        <gravitee-gateway-api.version>1.34.2</gravitee-gateway-api.version>
+        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
+        <gravitee-common.version>1.27.0</gravitee-common.version>
+        <gravitee-expression-language.version>1.8.0</gravitee-expression-language.version>
         <tomitribe-http-signatures.version>1.7</tomitribe-http-signatures.version>
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
         <!-- Property used by the publication job in CI-->
@@ -66,6 +67,13 @@
             <groupId>io.gravitee.common</groupId>
             <artifactId>gravitee-common</artifactId>
             <version>${gravitee-common.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.el</groupId>
+            <artifactId>gravitee-expression-language</artifactId>
+            <version>${gravitee-expression-language.version}</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION

**Issue**
https://github.com/gravitee-io/issues/issues/8488
 

**Description**

BREAKING CHANGE: make policy compatible APIM >= 3.15.x. The policy will no longer be compatible in APIM <= 3.14.x


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-fix-3-18-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-http-signature/2.0.0-fix-3-18-SNAPSHOT/gravitee-policy-http-signature-2.0.0-fix-3-18-SNAPSHOT.zip)
  <!-- Version placeholder end -->
