### PR TITLE
Apim 2140 http sign

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,8 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@2.0
+    gravitee: gravitee-io/gravitee@4.1.0
+
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)
@@ -22,7 +23,7 @@ workflows:
     setup_release:
         when:
             matches:
-                pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+                pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
                 value: << pipeline.git.tag >>
         jobs:
             - gravitee/setup_plugin-release-config:
@@ -32,4 +33,4 @@ workflows:
                               - /.*/
                       tags:
                           only:
-                              - /^[0-9]+\.[0-9]+\.[0-9]+$/
+                              - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,14 +1,22 @@
 {
   "extends": [
-    "config:base",
-    "schedule:earlyMondays"
+    "config:base"
   ],
-  "prConcurrentLimit": 3,
   "rebaseWhen": "conflicted",
   "packageRules": [
     {
       "matchDatasources": ["orb"],
-      "rangeStrategy": "replace"
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "automergeType": "branch",
+      "semanticCommitType": "ci"
+    },
+    {
+      "matchDepTypes": ["provided", "test", "build", "import", "parent"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "automergeType": "branch",
+      "semanticCommitType": "chore"
     }
   ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -32,10 +32,11 @@
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
         <!-- <version>19</version> -->
-        <version>19.2.1</version>
+        <version>21.0.1</version>
     </parent>
 
     <properties>
+        <gravitee-bom.version>5.0.0</gravitee-bom.version>
         <gravitee-gateway.version>3.6.3</gravitee-gateway.version>
         <gravitee-gateway-api.version>1.31.0</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.10.0</gravitee-policy-api.version>
@@ -45,6 +46,20 @@
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Gravitee dependencies -->
+            <!-- Import bom to properly inherit all dependencies -->
+            <dependency>
+                <groupId>io.gravitee</groupId>
+                <artifactId>gravitee-bom</artifactId>
+                <version>${gravitee-bom.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <!-- Provided scope -->
@@ -69,23 +84,15 @@
             <scope>provided</scope>
         </dependency>
 
-<!--        <dependency>-->
-<!--            <groupId>org.tomitribe</groupId>-->
-<!--            <artifactId>tomitribe-http-signatures</artifactId>-->
-<!--            <version>${tomitribe-http-signatures.version}</version>-->
-<!--        </dependency>-->
-
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>${spring.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -93,7 +100,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -22,3 +22,4 @@ class=io.gravitee.policy.httpsignature.HttpSignaturePolicy
 type=policy
 category=security
 icon=http-signature.svg
+proxy=REQUEST

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,6 +1,7 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "id": "urn:jsonschema:io:gravitee:policy:httpsignature:configuration:HttpSignaturePolicyConfiguration",
+  "additionalProperties": false,
   "properties": {
     "scheme" : {
       "title": "Scheme",
@@ -16,6 +17,12 @@
         "titleMap": {
           "AUTHORIZATION": "\"Signature\" HTTP Authentication Scheme",
           "SIGNATURE": "\"Signature\" HTTP Header"
+        }
+      },
+      "gioConfig": {
+        "banner": {
+          "title": "Scheme",
+          "text": "<ul><li>AUTHORIZATION: \"Signature\" HTTP Authentication Scheme</li><li>SIGNATURE: \"Signature\" HTTP Header</li></ul>"
         }
       }
     },


### PR DESCRIPTION
**Issue**

APIM-2140

**Description**

* update renovate
* update cci & gravitee-parent
* update schema form & add exec phase
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.6.0-apim-2140-http-sign-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-http-signature/1.6.0-apim-2140-http-sign-SNAPSHOT/gravitee-policy-http-signature-1.6.0-apim-2140-http-sign-SNAPSHOT.zip)
  <!-- Version placeholder end -->
