### PR TITLE
fix: update policy description

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default
-*       @gravitee-io/apim @gravitee-io/archi
+*       @gravitee-io/apim

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 **Issue**
 
-https://github.com/gravitee-io/issues/issues/XXXXX
+https://gravitee.atlassian.net/browse/APIM-XXXX
 
 **Description**
 

--- a/README.adoc
+++ b/README.adoc
@@ -40,9 +40,7 @@ NOTE: Current version of the policy does not support *Digest*, *(request-target)
 
 |===
 |Plugin version | APIM version
-
-|1.5 and upper               | 3.15.x to latest
-|Up to 1.4                   | Up to 3.14.x
+|1.x            | All supported versions
 |===
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,12 +26,11 @@
     <version>1.6.0</version>
 
     <name>Gravitee.io APIM - Policy - HTTP Signature</name>
-    <description>Description of the HTTP Signature Gravitee Policy</description>
+    <description>Enforce consumers to send a signature identifying the requests to ensure their identity</description>
 
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <!-- <version>19</version> -->
         <version>21.0.1</version>
     </parent>
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-2187
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.6.1-update-description-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-http-signature/1.6.1-update-description-SNAPSHOT/gravitee-policy-http-signature-1.6.1-update-description-SNAPSHOT.zip)
  <!-- Version placeholder end -->
